### PR TITLE
Fixing a bug with path on firebase-list

### DIFF
--- a/src/core/firebase/firebase-list.js
+++ b/src/core/firebase/firebase-list.js
@@ -2,9 +2,10 @@ import { firebaseDb } from './firebase';
 
 
 export class FirebaseList {
-  constructor(actions, modelClass) {
+  constructor(actions, modelClass, path = null) {
     this._actions = actions;
     this._modelClass = modelClass;
+    this._path = path;
   }
 
   get path() {
@@ -17,34 +18,34 @@ export class FirebaseList {
 
   push(value) {
     return new Promise((resolve, reject) => {
-      firebaseDb.ref(this.path)
+      firebaseDb.ref(this._path)
         .push(value, error => error ? reject(error) : resolve());
     });
   }
 
   remove(key) {
     return new Promise((resolve, reject) => {
-      firebaseDb.ref(`${this.path}/${key}`)
+      firebaseDb.ref(`${this._path}/${key}`)
         .remove(error => error ? reject(error) : resolve());
     });
   }
 
   set(key, value) {
     return new Promise((resolve, reject) => {
-      firebaseDb.ref(`${this.path}/${key}`)
+      firebaseDb.ref(`${this._path}/${key}`)
         .set(value, error => error ? reject(error) : resolve());
     });
   }
 
   update(key, value) {
     return new Promise((resolve, reject) => {
-      firebaseDb.ref(`${this.path}/${key}`)
+      firebaseDb.ref(`${this._path}/${key}`)
         .update(value, error => error ? reject(error) : resolve());
     });
   }
 
   subscribe(emit) {
-    let ref = firebaseDb.ref(this.path);
+    let ref = firebaseDb.ref(this._path);
     let initialized = false;
     let list = [];
 


### PR DESCRIPTION
There were some missing underscores on the path member of the class. Therefore it was being discarded. Also added the ability to define the path on construction (it makes the code cleaner on other places)